### PR TITLE
Move Suggested Forum to Stack Overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,4 @@ library(CausalImpact)
 * Manuscript:
   [Brodersen et al., Annals of Applied Statistics (2015)](http://research.google.com/pubs/pub41854.html)
 * Discussion forum:
-  [StackExchange](http://stats.stackexchange.com/questions/tagged/causalimpact)
+  [Stackoverflow](http://stackoverflow.com/questions/tagged/causalimpact)


### PR DESCRIPTION
The moderators at Cross Validated have started closing discussions about the CausalImpact package as off topic because they "focus[] on programming, debugging, or performing routine operations within a statistical computing platform" rather than the statistics themselves.  (see https://stats.stackexchange.com/questions/284204/q-r-causalimpact-order-of-control-time-series/ for an example) Rather than continue to annoy those mods, you may want to move the suggested forum for support questions to Stack Exchange.