### PR TITLE
small changes for rubustness/idiomacy

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,6 @@ Copyright: Copyright (C) 2014-2017 Google, Inc.
 Version: 1.2.3
 VignetteBuilder: knitr
 License: Apache License 2.0 | file LICENSE
-Imports: assertthat (>= 0.2.0), Boom, dplyr, ggplot2, zoo
+Imports: assertthat (>= 0.2.0), Boom, dplyr (>= 0.7.0), ggplot2, zoo
 Depends: bsts (>= 0.7.0)
 Suggests: knitr, testthat

--- a/R/impact_inference.R
+++ b/R/impact_inference.R
@@ -174,6 +174,14 @@ ComputeCumulativePredictions <- function(y.samples, point.pred, y,
   return(cum.pred)
 }
 
+# Tell R CMD check to treat columns of data frames used in `dplyr::mutate` as
+# global variables; this avoids false positives of "no visible binding for
+# global variable ..." during the check.
+if(getRversion() >= "2.15.1") {
+  utils::globalVariables(c("AbsEffect", "AbsEffect.lower", "AbsEffect.upper",
+                           "AbsEffect.sd", "Pred"))
+}
+
 CompileSummaryTable <- function(y.post, y.samples.post,
                                 point.pred.mean.post, alpha = 0.05) {
   # Creates a table of statistics that summarise the post-intervention period.
@@ -238,10 +246,10 @@ CompileSummaryTable <- function(y.post, y.samples.post,
       AbsEffect.sd = c(sd(rowMeans(y.repmat.post - y.samples.post)),
                        sd(rowSums(y.repmat.post - y.samples.post))))
   summary <- dplyr::mutate(summary,
-                           RelEffect = UQ(quo(AbsEffect / Pred)),
-                           RelEffect.lower = UQ(quo(AbsEffect.lower / Pred)),
-                           RelEffect.upper = UQ(quo(AbsEffect.upper / Pred)),
-                           RelEffect.sd = UQ(quo(AbsEffect.sd / Pred)))
+                           RelEffect = AbsEffect / Pred,
+                           RelEffect.lower = AbsEffect.lower / Pred,
+                           RelEffect.upper = AbsEffect.upper / Pred,
+                           RelEffect.sd = AbsEffect.sd / Pred)
   rownames(summary) <- c("Average", "Cumulative")
 
   # Add interval coverage, defined by alpha

--- a/R/impact_misc.R
+++ b/R/impact_misc.R
@@ -56,8 +56,9 @@ cumsum.na.rm <- function(x) {
   if (is.null(x)) {
     return(x)
   }
-  s <- cumsum(ifelse(is.na(x), 0, x))
-  s[is.na(x)] <- NA
+  nas <- is.na(x)
+  s <- cumsum(ifelse(nas, 0, x))
+  s[nas] <- NA
   return(s)
 }
 

--- a/R/impact_model.R
+++ b/R/impact_model.R
@@ -48,7 +48,7 @@ ObservationsAreIllConditioned <- function(y) {
     ill.conditioned <- TRUE
 
   # Fewer than 3 non-NA values?
-  } else if (length(y[!is.na(y)]) < 3) {
+  } else if (sum(! is.na(y)) < 3) {
     warning("Aborting inference due to fewer than 3 non-NA values in input")
     ill.conditioned <- TRUE
 

--- a/R/impact_plot.R
+++ b/R/impact_plot.R
@@ -36,18 +36,18 @@ CreateDataFrameForPlot <- function(impact) {
 
   # Reshape data frame
   tmp1 <- data[, c("time", "response", "point.pred", "point.pred.lower",
-                   "point.pred.upper")]
+                   "point.pred.upper"), drop = FALSE]
   names(tmp1) <- c("time", "response", "mean", "lower", "upper")
   tmp1$baseline <- NA
   tmp1$metric <- "original"
   tmp2 <- data[, c("time", "response", "point.effect", "point.effect.lower",
-                   "point.effect.upper")]
+                   "point.effect.upper"), drop = FALSE]
   names(tmp2) <- c("time", "response", "mean", "lower", "upper")
   tmp2$baseline <- 0
   tmp2$metric <- "pointwise"
   tmp2$response <- NA
   tmp3 <- data[, c("time", "response", "cum.effect", "cum.effect.lower",
-                   "cum.effect.upper")]
+                   "cum.effect.upper"), drop = FALSE]
   names(tmp3) <- c("time", "response", "mean", "lower", "upper")
   tmp3$metric <- "cumulative"
   tmp3$baseline <- 0
@@ -118,7 +118,7 @@ CreateImpactPlot <- function(impact, metrics = c("original", "pointwise",
   # Select metrics to display (and their order)
   assert_that(is.vector(metrics))
   metrics <- match.arg(metrics, several.ok = TRUE)
-  data <- data[data$metric %in% metrics, ]
+  data <- data[data$metric %in% metrics, , drop = FALSE]
   data$metric <- factor(data$metric, metrics)
 
   # Initialize plot


### PR DESCRIPTION
This pull request updates the package to use the tidyeval framework, introduced in `dplyr` 0.7.0.  This has several advantages over the current non-standard evaluation use of `dplyr` in `CausalImpact`, which are descried in this [vignette](https://rpubs.com/hadley/dplyr-programming) by Hadley Wickham.