### PR TITLE
Fixing warnings in plot

### DIFF
--- a/R/impact_plot.R
+++ b/R/impact_plot.R
@@ -141,14 +141,16 @@ CreateImpactPlot <- function(impact, metrics = c("original", "pointwise",
 
   # Add zero line to pointwise and cumulative plot
   q <- q + geom_line(aes(y = baseline),
-                     colour = "darkgrey", size = 0.8, linetype = "solid")
+                     colour = "darkgrey", size = 0.8, linetype = "solid", 
+                     na.rm = TRUE)
 
   # Add point predictions
   q <- q + geom_line(aes(y = mean), data,
-                     size = 0.6, colour = "darkblue", linetype = "dashed")
+                     size = 0.6, colour = "darkblue", linetype = "dashed",
+                     na.rm = TRUE)
 
   # Add observed data
-  q <- q + geom_line(aes(y = response), size = 0.6)
+  q <- q + geom_line(aes(y = response), size = 0.6,  na.rm = TRUE)
   return(q)
 }
 


### PR DESCRIPTION
## Original Problem

When calling the `plot` function, warnings are returned.  

This addresses Issues #23 #20 #9 

See reprex below.

``` r
library(CausalImpact)
#> Loading required package: bsts
#> Loading required package: BoomSpikeSlab
#> Loading required package: Boom
#> Loading required package: MASS
#> 
#> Attaching package: 'Boom'
#> The following object is masked from 'package:stats':
#> 
#>     rWishart
#> Loading required package: zoo
#> 
#> Attaching package: 'zoo'
#> The following objects are masked from 'package:base':
#> 
#>     as.Date, as.Date.numeric
#> Loading required package: xts

set.seed(1)
x1 <- 100 + arima.sim(model = list(ar = 0.999), n = 100)
y <- 1.2 * x1 + rnorm(100)
y[71:100] <- y[71:100] + 10
data <- cbind(y, x1)

pre.period <- c(1, 70)
post.period <- c(71, 100)

impact <- CausalImpact(data, pre.period, post.period)

plot(impact)
#> Warning: Removed 100 rows containing missing values (geom_path).
#> Warning: Removed 200 rows containing missing values (geom_path).
```

![](https://i.imgur.com/AXAQBlB.png)

<sup>Created on 2019-04-15 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

## Solution  

The issue looks like its caused from NA's in the data frame that are created from the impact object. When faceting, some data such as the response or baseline are only relevant for certain facets. By including `na.rm = TRUE` in the ggplot calls silences these warnings.   

``` r
library(CausalImpact)
#> Loading required package: bsts
#> Loading required package: BoomSpikeSlab
#> Loading required package: Boom
#> Loading required package: MASS
#> 
#> Attaching package: 'Boom'
#> The following object is masked from 'package:stats':
#> 
#>     rWishart
#> Loading required package: zoo
#> 
#> Attaching package: 'zoo'
#> The following objects are masked from 'package:base':
#> 
#>     as.Date, as.Date.numeric
#> Loading required package: xts

set.seed(1)
x1 <- 100 + arima.sim(model = list(ar = 0.999), n = 100)
y <- 1.2 * x1 + rnorm(100)
y[71:100] <- y[71:100] + 10
data <- cbind(y, x1)

pre.period <- c(1, 70)
post.period <- c(71, 100)

impact <- CausalImpact(data, pre.period, post.period)

plot(impact)
```

![](https://i.imgur.com/0QppOMr.png)

<sup>Created on 2019-04-15 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>



