### PR TITLE
Resolves Relative Effects incorrect (wrong sign) when post-period mean is negative #31

### DIFF
--- a/R/impact_inference.R
+++ b/R/impact_inference.R
@@ -226,7 +226,7 @@ CompileSummaryTable <- function(y.post, y.samples.post,
   # Compile summary statistics
   summary <- data.frame(
       Actual = c(mean(y.post), sum(y.post)),
-      Pred = c(mean(point.pred.mean.post), sum(point.pred.mean.post)),
+      Pred = c(mean(abs(point.pred.mean.post)), sum(abs(point.pred.mean.post))),
       Pred.lower = c(quantile(rowMeans(y.samples.post), prob.lower),
                      quantile(rowSums(y.samples.post), prob.lower)),
       Pred.upper = c(quantile(rowMeans(y.samples.post), prob.upper),

--- a/R/impact_inference.R
+++ b/R/impact_inference.R
@@ -226,7 +226,7 @@ CompileSummaryTable <- function(y.post, y.samples.post,
   # Compile summary statistics
   summary <- data.frame(
       Actual = c(mean(y.post), sum(y.post)),
-      Pred = c(abs(mean(point.pred.mean.post)), abs(sum(point.pred.mean.post))),
+      Pred = c(mean(point.pred.mean.post), abs(sum(point.pred.mean.post))),
       Pred.lower = c(quantile(rowMeans(y.samples.post), prob.lower),
                      quantile(rowSums(y.samples.post), prob.lower)),
       Pred.upper = c(quantile(rowMeans(y.samples.post), prob.upper),

--- a/R/impact_inference.R
+++ b/R/impact_inference.R
@@ -226,7 +226,7 @@ CompileSummaryTable <- function(y.post, y.samples.post,
   # Compile summary statistics
   summary <- data.frame(
       Actual = c(mean(y.post), sum(y.post)),
-      Pred = c(mean(point.pred.mean.post), sum(abs(point.pred.mean.post))),
+      Pred = c(mean(point.pred.mean.post), sum(point.pred.mean.post)),
       Pred.lower = c(quantile(rowMeans(y.samples.post), prob.lower),
                      quantile(rowSums(y.samples.post), prob.lower)),
       Pred.upper = c(quantile(rowMeans(y.samples.post), prob.upper),
@@ -246,10 +246,10 @@ CompileSummaryTable <- function(y.post, y.samples.post,
       AbsEffect.sd = c(sd(rowMeans(y.repmat.post - y.samples.post)),
                        sd(rowSums(y.repmat.post - y.samples.post))))
   summary <- dplyr::mutate(summary,
-                           RelEffect = AbsEffect / Pred,
-                           RelEffect.lower = AbsEffect.lower / Pred,
-                           RelEffect.upper = AbsEffect.upper / Pred,
-                           RelEffect.sd = AbsEffect.sd / Pred)
+                           RelEffect = AbsEffect / abs(Pred),
+                           RelEffect.lower = AbsEffect.lower / abs(Pred),
+                           RelEffect.upper = AbsEffect.upper / abs(Pred),
+                           RelEffect.sd = AbsEffect.sd / abs(Pred))
   rownames(summary) <- c("Average", "Cumulative")
 
   # Add interval coverage, defined by alpha

--- a/R/impact_inference.R
+++ b/R/impact_inference.R
@@ -226,7 +226,7 @@ CompileSummaryTable <- function(y.post, y.samples.post,
   # Compile summary statistics
   summary <- data.frame(
       Actual = c(mean(y.post), sum(y.post)),
-      Pred = c(mean(abs(point.pred.mean.post)), sum(abs(point.pred.mean.post))),
+      Pred = c(mean(point.pred.mean.post), sum(abs(point.pred.mean.post))),
       Pred.lower = c(quantile(rowMeans(y.samples.post), prob.lower),
                      quantile(rowSums(y.samples.post), prob.lower)),
       Pred.upper = c(quantile(rowMeans(y.samples.post), prob.upper),

--- a/R/impact_inference.R
+++ b/R/impact_inference.R
@@ -226,7 +226,7 @@ CompileSummaryTable <- function(y.post, y.samples.post,
   # Compile summary statistics
   summary <- data.frame(
       Actual = c(mean(y.post), sum(y.post)),
-      Pred = c(mean(point.pred.mean.post), abs(sum(point.pred.mean.post))),
+      Pred = c(mean(point.pred.mean.post), sum(point.pred.mean.post)),
       Pred.lower = c(quantile(rowMeans(y.samples.post), prob.lower),
                      quantile(rowSums(y.samples.post), prob.lower)),
       Pred.upper = c(quantile(rowMeans(y.samples.post), prob.upper),

--- a/R/impact_inference.R
+++ b/R/impact_inference.R
@@ -226,7 +226,7 @@ CompileSummaryTable <- function(y.post, y.samples.post,
   # Compile summary statistics
   summary <- data.frame(
       Actual = c(mean(y.post), sum(y.post)),
-      Pred = c(mean(point.pred.mean.post), sum(point.pred.mean.post)),
+      Pred = c(abs(mean(point.pred.mean.post)), abs(sum(point.pred.mean.post))),
       Pred.lower = c(quantile(rowMeans(y.samples.post), prob.lower),
                      quantile(rowSums(y.samples.post), prob.lower)),
       Pred.upper = c(quantile(rowMeans(y.samples.post), prob.upper),


### PR DESCRIPTION
This request resolves the Relative Effects incorrect (wrong sign) when post-period mean is negative #31 that was posted [here](https://github.com/google/CausalImpact/issues/31) and confirmed by myself and others. I have tested this fix and it resolves the issue without creating new issues. True negative impacts are still recorded as such, but false-negatives are avoided. Please confirm if this is a helpful pull request or not. Thank you.