### PR TITLE
Use \donttest for slow examples

### DIFF
--- a/man/CausalImpact.Rd
+++ b/man/CausalImpact.Rd
@@ -222,6 +222,7 @@
   Kay H. Brodersen \email{kbrodersen@google.com}
 }
 \examples{
+\donttest{
 # Example 1
 #
 # Example analysis on a simple artificial dataset
@@ -246,7 +247,6 @@ plot(impact$model$bsts.model, "coefficients")
 # For further output, type:
 names(impact)
 
-\dontrun{
 # Example 2
 #
 # Weekly time series: same data as in example 1, annotated


### PR DESCRIPTION
This example is observed to run >60 seconds in some cases; it's better to skip such slow examples on CI tools like `R CMD check`, while still letting users get them by running `example()`. Hence `\donttest{}` over `\dontrun{}` (the latter will also skip running the code under `example()`).